### PR TITLE
(Fix 2) Fixed issues with sample projects (CDA.R5Samples & CDA.Sample…

### DIFF
--- a/src/CDA.Generator/Generator/CDAGenerator.cs
+++ b/src/CDA.Generator/Generator/CDAGenerator.cs
@@ -3295,43 +3295,53 @@ namespace Nehta.VendorLibrary.CDA.Generator
             return CDAGeneratorHelper.CreateXml(clinicalDocument, authors, legalAuthenticator, authenticators, recipients, participants, components, nonXmlBody, serviceReferral.IncludeLogo, serviceReferral.LogoByte, typeof(ServiceReferral));
         }
 
-        #endregion
+    #endregion
 
-        #region Setup and Validation
+    #region Setup and Validation
 
-        /// <summary>
-        /// Verifies that the logo path location is a valid path and is included in the bin directory
-        /// </summary>
-        /// <returns>XmlDocument (CDA - EventSummary)</returns>
-        public static void LogoSetupAndValidation(string logoPath,byte[] logoByte, bool includeLogo, ValidationBuilder vb)
+    /// <summary>
+    /// Verifies that the logo path location is a valid path and is included in the bin directory
+    /// </summary>
+    /// <returns>XmlDocument (CDA - EventSummary)</returns>
+    public static void LogoSetupAndValidation(string logoPath, byte[] logoByte, bool includeLogo, ValidationBuilder vb)
+    {
+      if (includeLogo)
+      {
+        bool UserProvidedLogoFileExists = false;
+        bool DefaultLogoFileExists = File.Exists("Logo.png");
+
+        //Use the Logo in the path provided else use the default. Note that a logoPath of "." is the same as not provided
+        if (!logoPath.IsNullOrEmptyWhitespace() && logoPath != ".")
         {
-          if (includeLogo)
+          if (File.Exists(System.IO.Path.Combine(logoPath, "Logo.png")))
           {
-            var fileExists = File.Exists("Logo.png");
-
-            if (!logoPath.IsNullOrEmptyWhitespace())
-            {
-              if (fileExists)
-              {
-                 File.Copy(logoPath, "Logo.png", true);
-              }
-              else
-              {
-                vb.AddValidationMessage(vb.PathName, string.Empty, string.Format("The path '{0}' does not contain an image", logoPath));
-              }
-            }
-
-            if (!fileExists && logoByte != null || !logoPath.IsNullOrEmptyWhitespace() && logoByte != null) 
-            {
-                vb.AddValidationMessage("Logo", null, "The LogoPath and LogoByte are Mutually exclusive, please pass a file to the file path or provide an byte array entry");
-            }
-
-            if (logoByte == null && !fileExists)
-            {
-              vb.AddValidationMessage(vb.PathName, string.Empty, "Logo.png needs to be included in the output directory or include a byte array if 'IncludeLogo' is true");
-            }
+            //If the user of the library has set a location for the Logo 'logoPath' and it exists then copy that
+            //logo file to the Application directory / bin
+            File.Copy(System.IO.Path.Combine(logoPath, "Logo.png"), "Logo.png", true);
+            UserProvidedLogoFileExists = true;
+          }
+          else
+          {
+            //No Logo file found in the path they provided, So they wanted to use their Logo file but it can not be found, so error.
+            vb.AddValidationMessage(vb.PathName, string.Empty, string.Format("The provided logo path '{0}' does not contain an image", logoPath));
           }
         }
-        #endregion
+
+        //Can only have one or either the User provided Logo file or the User provided Logo Byte Array
+        //This detects that we have both.
+        if (logoByte != null && UserProvidedLogoFileExists)
+        {
+          vb.AddValidationMessage("Logo", null, "The LogoPath and LogoByte are Mutually exclusive, please pass a file to the file path or provide an byte array entry");
+        }
+
+        //Check we have either a Logo Bytes or a logo file regardless of which logo file it is, default or user provided file
+        //If all are null or false then we have no Logo at all and yet includeLogo was set to true, so error
+        if (logoByte == null && !UserProvidedLogoFileExists && !DefaultLogoFileExists)
+        {
+          vb.AddValidationMessage(vb.PathName, string.Empty, "Logo.png needs to be included in the output directory or include a byte array if 'IncludeLogo' is true");
+        }
+      }
     }
+    #endregion
+  }
 }

--- a/src/CDA.R5Sample/AdvanceCareInformationSample.cs
+++ b/src/CDA.R5Sample/AdvanceCareInformationSample.cs
@@ -157,6 +157,7 @@ namespace CDA.R5Samples
 
             // Include Logo
             advanceCareInformation.IncludeLogo = true;
+            advanceCareInformation.LogoPath = OutputFolderPath;
 
             // Set Creation Time
             advanceCareInformation.DocumentCreationTime = new ISO8601DateTime(DateTime.Now);

--- a/src/CDA.R5Sample/DiagnosticImagingReportSample.cs
+++ b/src/CDA.R5Sample/DiagnosticImagingReportSample.cs
@@ -166,6 +166,7 @@ namespace CDA.R5Samples
 
             // Include Logo
             diagnosticImagingReport.IncludeLogo = true;
+            diagnosticImagingReport.LogoPath = OutputFolderPath;
 
             // Set Creation Time
             diagnosticImagingReport.DocumentCreationTime = new ISO8601DateTime(DateTime.Now);

--- a/src/CDA.R5Sample/PathologyReportWithStructuredContentSample.cs
+++ b/src/CDA.R5Sample/PathologyReportWithStructuredContentSample.cs
@@ -170,6 +170,7 @@ namespace CDA.R5Samples
 
             // Include Logo
             pathologyReportWithStructuredContent.IncludeLogo = true;
+            pathologyReportWithStructuredContent.LogoPath = OutputFolderPath;
 
             // Set Creation Time
             pathologyReportWithStructuredContent.DocumentCreationTime = new ISO8601DateTime(DateTime.Now);

--- a/src/CDA.R5Sample/PathologyResultReportSample.cs
+++ b/src/CDA.R5Sample/PathologyResultReportSample.cs
@@ -158,6 +158,7 @@ namespace CDA.R5Samples
 
             // Include Logo
             pathologyResultReport.IncludeLogo = true;
+            pathologyResultReport.LogoPath = OutputFolderPath;
 
             // Set Creation Time
             pathologyResultReport.DocumentCreationTime = new ISO8601DateTime(DateTime.Now);

--- a/src/CDA.Sample/EDischargeSummarySample.cs
+++ b/src/CDA.Sample/EDischargeSummarySample.cs
@@ -294,6 +294,7 @@ namespace Nehta.VendorLibrary.CDA.Sample
 
             // Include Logo
             eDischargeSummary.IncludeLogo = true;
+            eDischargeSummary.LogoPath = OutputFolderPath;
 
             // Set Creation Time
             eDischargeSummary.DocumentCreationTime = new ISO8601DateTime(DateTime.Now.AddHours(9));

--- a/src/CDA.Sample/EReferralSample.cs
+++ b/src/CDA.Sample/EReferralSample.cs
@@ -398,10 +398,10 @@ namespace Nehta.VendorLibrary.CDA.Sample
             eReferral.DocumentCreationTime = new ISO8601DateTime(DateTime.Now);
 
             // Include Logo
-            eReferral.IncludeLogo = true;
+            eReferral.IncludeLogo = true;            
 
             // Note: Populate ByteArray Logo
-            eReferral.LogoByte = BaseCDAModel.FileToByteArray("Logo.png");
+            eReferral.LogoByte = BaseCDAModel.FileToByteArray(System.IO.Path.Combine(OutputFolderPath, "Logo.png"));
 
             #region Setup and populate the CDA context model
 

--- a/src/CDA.Sample/EventSummarySample.cs
+++ b/src/CDA.Sample/EventSummarySample.cs
@@ -214,6 +214,7 @@ namespace Nehta.VendorLibrary.CDA.Sample
 
             // Include Logo
             eventSummary.IncludeLogo = true;
+            eventSummary.LogoPath = OutputFolderPath;
 
             // Set Creation Time
             eventSummary.DocumentCreationTime = new ISO8601DateTime(DateTime.Now);

--- a/src/CDA.Sample/Program.cs
+++ b/src/CDA.Sample/Program.cs
@@ -46,40 +46,41 @@ namespace Nehta.VendorLibrary.CDA.Sample
             var eReferralCda1A = eReferralSampleCode.PopulateEReferralSample_1A("EReferral_1A.xml");
             var eReferralCda1B = eReferralSampleCode.PopulateEReferralSample_1B("EReferral_1B.xml");
             var eReferralCda1N = eReferralSampleCode.PopulateEReferralSample_1B_NarrativeExample("EReferral_1B_NB.xml");
-            LevelsGenerator.Generate2("EReferral_3A_Max.xml", "EReferral_2.xml");
+            LevelsGeneratorPathCorrections("EReferral_3A_Max.xml", "EReferral_2.xml", EReferralSample.OutputFolderPath);
 
             var sharedHealthSummarySampleCode = new SharedHealthSummarySample();
             var minSharedHealthSummaryCda = sharedHealthSummarySampleCode.MinPopulatedSharedHealthSummarySample("SharedHealthSummary_3A_Min.xml");
             var maxSharedHealthSummaryCda = sharedHealthSummarySampleCode.MaxPopulatedSharedHealthSummarySample("SharedHealthSummary_3A_Max.xml");
             var sharedHealthSummaryCda_1A = sharedHealthSummarySampleCode.PopulateSharedHealthSummarySample_1A("SharedHealthSummary_1A.xml");
-            LevelsGenerator.Generate2("SharedHealthSummary_3A_Max.xml", "SharedHealthSummary_2.xml");
+            LevelsGeneratorPathCorrections("SharedHealthSummary_3A_Max.xml", "SharedHealthSummary_2.xml", SharedHealthSummarySample.OutputFolderPath);
+      
 
             var specialistLetterSampleCode = new SpecialistLetterSample();
             var minSpecialistLetterCda = specialistLetterSampleCode.MinPopulatedSpecialistLetterSample("SpecialistLetter_3A_Min.xml");
             var maxSpecialistLetterCda = specialistLetterSampleCode.MaxPopulatedSpecialistLetterSample("SpecialistLetter_3A_Max.xml");
             var specialistLetterCda1A = specialistLetterSampleCode.PopulateSpecialistLetterSample_1A("SpecialistLetter_1A.xml");
             var specialistLetterCda1B = specialistLetterSampleCode.PopulateSpecialistLetterSample_1B("SpecialistLetter_1B.xml");
-            LevelsGenerator.Generate2("SpecialistLetter_3A_Max.xml", "SpecialistLetter_2.xml");
+            LevelsGeneratorPathCorrections("SpecialistLetter_3A_Max.xml", "SpecialistLetter_2.xml", SpecialistLetterSample.OutputFolderPath);
 
             var dischargeSummarySampleCode = new EDischargeSummarySample();
             var minDischargeSummaryCda = dischargeSummarySampleCode.MinPopulatedEDischargeSummary("DischargeSummary_3A_Min.xml");
             var maxDischargeSummaryCda = dischargeSummarySampleCode.MaxPopulatedEDischargeSummary("DischargeSummary_3A_Max.xml");
             var dischargeSummaryCda1A = dischargeSummarySampleCode.PopulateEDischargeSummarySample_1A("DischargeSummary_1A.xml");
             var dischargeSummaryCda1B = dischargeSummarySampleCode.PopulateEDischargeSummarySample_1B("DischargeSummary_1B.xml");
-            LevelsGenerator.Generate2("DischargeSummary_3A_Max.xml", "DischargeSummary_2.xml");
+            LevelsGeneratorPathCorrections("DischargeSummary_3A_Max.xml", "DischargeSummary_2.xml", EDischargeSummarySample.OutputFolderPath);
 
             var eEventSummarySampleCode = new EventSummarySample();
             var minEventSummaryCda = eEventSummarySampleCode.MinPopulatedEventSummary("EventSummary_3A_Min.xml");
             var maxEventSummaryCda = eEventSummarySampleCode.MaxPopulatedEventSummary("EventSummary_3A_Max.xml");
             var eventSummaryCda1A = eEventSummarySampleCode.PopulateEventSummarySample_1A("EventSummary_1A.xml");
-            LevelsGenerator.Generate2("EventSummary_3A_Max.xml", "EventSummary_2.xml");
+            LevelsGeneratorPathCorrections("EventSummary_3A_Max.xml", "EventSummary_2.xml", EventSummarySample.OutputFolderPath);
 
             var serviceReferralSampleCode = new ServiceReferralSample();
             var minServiceReferralCda = serviceReferralSampleCode.MinPopulatedServiceReferralSample("ServiceReferral_3A_Min.xml");
             var maxServiceReferralCda = serviceReferralSampleCode.MaxPopulatedServiceReferralSample("ServiceReferral_3A_Max.xml");
             var serviceReferralCda1A = serviceReferralSampleCode.PopulateServiceReferralSample_1A("ServiceReferral_1A.xml");
             var serviceReferralCda1B = serviceReferralSampleCode.PopulateServiceReferralSample_1B("ServiceReferral_1B.xml");
-            LevelsGenerator.Generate2("ServiceReferral_3A_Max.xml", "ServiceReferral_2.xml");
+            LevelsGeneratorPathCorrections("ServiceReferral_3A_Max.xml", "ServiceReferral_2.xml", ServiceReferralSample.OutputFolderPath);
 
             var genericObjectReuseSampleCode = new GenericObjectReuseSample();
             var sampleSubjectOfCare = genericObjectReuseSampleCode.PopulateSubjectOfCare();
@@ -89,7 +90,12 @@ namespace Nehta.VendorLibrary.CDA.Sample
             var sampleRecipient = genericObjectReuseSampleCode.PopulateRecipient();
         }
 
-        static void PrepareOutputFolder(string folderPath)
+    private static void LevelsGeneratorPathCorrections(string input, string output, string OutPutFolderPath)
+    {
+      LevelsGenerator.Generate2(System.IO.Path.Combine(OutPutFolderPath, input), System.IO.Path.Combine(OutPutFolderPath, output));      
+    }
+
+    static void PrepareOutputFolder(string folderPath)
         {
             if (Directory.Exists(folderPath))
             {

--- a/src/CDA.Sample/ServiceReferralSample.cs
+++ b/src/CDA.Sample/ServiceReferralSample.cs
@@ -261,6 +261,7 @@ namespace Nehta.VendorLibrary.CDA.Sample
 
             // Include Logo
             serviceReferral.IncludeLogo = true;
+            serviceReferral.LogoPath = OutputFolderPath;
 
             // Set Creation Time
             serviceReferral.DocumentCreationTime = new ISO8601DateTime(DateTime.Now, ISO8601DateTime.Precision.Second);

--- a/src/CDA.Sample/SharedHealthSummarySample.cs
+++ b/src/CDA.Sample/SharedHealthSummarySample.cs
@@ -212,6 +212,7 @@ namespace Nehta.VendorLibrary.CDA.Sample
 
             // Include Logo
             sharedHealthSummary.IncludeLogo = true;
+            sharedHealthSummary.LogoPath = OutputFolderPath;
 
             // Set Creation Time
             sharedHealthSummary.DocumentCreationTime = new ISO8601DateTime(DateTime.Now, ISO8601DateTime.Precision.Second);

--- a/src/CDA.Sample/SpecialistLetterSample.cs
+++ b/src/CDA.Sample/SpecialistLetterSample.cs
@@ -269,7 +269,8 @@ namespace Nehta.VendorLibrary.CDA.Sample
 
             // Include Logo
             specialistLetter.IncludeLogo = true;
-
+            specialistLetter.LogoPath = OutputFolderPath;
+            
             #region Setup and populate the CDA context model
 
             // Setup and populate the CDA context model


### PR DESCRIPTION
…) where they would both fail if the user provided an OutputFolder as an argument to the console project, in order to have the output content to go to a specified folder, rather than into the applications / bin folder.

When this was attempted the application would always fail on loading the Logo.png file, further more in the CDA.Sample project it would also fail when calling the 'LevelsGenerator.Generate2(inputPath, outputPath)' method as the users custom OutputFolder was not considered in this method call.
To resolve all this I have rewritten the method 'LogoSetupAndValidation' found in the CDAGenerator class and also updated every sample to explicitly set the 'LogoPath' to the users custom OutputFolder, for example 'serviceReferral.LogoPath = OutputFolderPath', the case where no custom OutputFolder is provided is also still covered.
I have also created a support method in the CDA.Sample project's root Program class called LevelsGeneratorPathCorrections(string input, string output, string OutPutFolderPath) which manages updating these paths to also consider the users custom OutputFolder.
I have then tested that all works for both sample project both when the users custom OutputFolder is provided and when it is not, in both cases the project now work correctly.

### Definition of Done

* [x] Code has been peer reviewed
* [x] Test coverage has been maintained or improved
* [x] All tests pass within CI
* [x] README is up to date
